### PR TITLE
Added androidx.documentfile as a dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,5 +28,6 @@
 		</config-file>
 
 		<source-file src="src/android/com/customautosys/saf_mediastore/SafMediastore.java" target-dir="src/com/customautosys/saf_mediastore/"/>
+		<framework src="androidx.documentfile:documentfile:1.0.1" />
 	</platform>
 </plugin>


### PR DESCRIPTION
Building a project which includes this plugin fails with a compile error because Documentfile class which is used in this plugin is not added to  the dependency.
```
cordova create . 
cordova platform add android
cordova plugin add  cordova-plugin-saf-mediastore
cordova build
```

```

> Task :app:compileDebugJavaWithJavac FAILED
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:21: error: package androidx.documentfile.provider does not exist
import androidx.documentfile.provider.DocumentFile;
                                     ^
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:176: error: cannot find symbol
                                DocumentFile documentFile=DocumentFile.fromTreeUri(
                                ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:176: error: cannot find symbol
                                DocumentFile documentFile=DocumentFile.fromTreeUri(
                                                          ^
  symbol:   variable DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:183: error: cannot find symbol
                                                DocumentFile subFolderDocumentFile=null;
                                                ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:184: error: cannot find symbol
                                                for(DocumentFile subFile:documentFile.listFiles()){
                                                    ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:193: error: cannot find symbol
                                DocumentFile file=null;
                                ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:194: error: cannot find symbol
                                for(DocumentFile subFile:documentFile.listFiles()){
                                    ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:306: error: cannot find symbol
                        DocumentFile documentFile=DocumentFile.fromTreeUri(
                        ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:306: error: cannot find symbol
                        DocumentFile documentFile=DocumentFile.fromTreeUri(
                                                  ^
  symbol:   variable DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:319: error: cannot find symbol
                                        DocumentFile subFolderDocumentFile=null;
                                        ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:320: error: cannot find symbol
                                        for(DocumentFile subFile:documentFile.listFiles()){
                                            ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:340: error: cannot find symbol
                        DocumentFile file=null;
                        ^
  symbol:   class DocumentFile
  location: class SafMediastore
C:\dev\words\a\platforms\android\app\src\main\java\com\customautosys\saf_mediastore\SafMediastore.java:341: error: cannot find symbol
                        for(DocumentFile subFile:documentFile.listFiles()){
                            ^
  symbol:   class DocumentFile
  location: class SafMediastore
13 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 13s
27 actionable tasks: 1 executed, 26 up-to-date
Command failed with exit code 1: C:\dev\words\a\platforms\android\gradlew -b C:\dev\words\a\platforms\android\build.gradle cdvBuildDebug
```

This pull request is to add it to classpaths as a dependency.

